### PR TITLE
remove currentTime.Stolen

### DIFF
--- a/cat/monitor_collector.go
+++ b/cat/monitor_collector.go
@@ -111,8 +111,7 @@ func (c *cpuInfoCollector) GetProperties() map[string]string {
 				currentTime.Softirq +
 				currentTime.Steal +
 				currentTime.Guest +
-				currentTime.GuestNice +
-				currentTime.Stolen
+				currentTime.GuestNice
 
 			if c.lastCPUTime > 0 {
 				cpuTime := currentCpuTime - c.lastCPUTime


### PR DESCRIPTION
参见这个issue：https://github.com/Meituan-Dianping/cat-go/issues/20
因为github.com/shirou/gopsutil/ 这个库已经在这次commit中删除了stolen https://github.com/shirou/gopsutil/commit/cae8efcffa765c9534442328d385bdd883faf5df 。所以cat-go的代码会编译出错。这次PR干的一件事情就是把currentTime.Stolen给删掉